### PR TITLE
Add base controller traits

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/bootstrap/controller/BackendController.scala
+++ b/src/main/scala/uk/gov/hmrc/play/bootstrap/controller/BackendController.scala
@@ -20,14 +20,16 @@ import play.api.mvc._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.HeaderCarrierConverter
 
-@deprecated("Use BackendController instead", "0.4.0")
-abstract class BaseController(cc: ControllerComponents) extends BackendController(cc)
-
-abstract class BackendController(cc: ControllerComponents)
-    extends AbstractController(cc)
+trait BackendBaseController
+  extends play.api.mvc.BaseController
     with Utf8MimeTypes
     with WithJsonBody
     with BackendHeaderCarrierProvider
+
+abstract class BackendController(override val controllerComponents: ControllerComponents) extends BackendBaseController
+
+@deprecated("Use BackendController instead", "0.4.0")
+abstract class BaseController(cc: ControllerComponents) extends BackendController(cc)
 
 trait BackendHeaderCarrierProvider {
   implicit protected def hc(implicit request: RequestHeader): HeaderCarrier =

--- a/src/main/scala/uk/gov/hmrc/play/bootstrap/controller/FrontendController.scala
+++ b/src/main/scala/uk/gov/hmrc/play/bootstrap/controller/FrontendController.scala
@@ -20,11 +20,14 @@ import play.api.mvc._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.HeaderCarrierConverter
 
-abstract class FrontendController(mcc: MessagesControllerComponents)
-    extends MessagesAbstractController(mcc)
+trait FrontendBaseController
+  extends MessagesBaseController
     with Utf8MimeTypes
     with WithJsonBody
     with FrontendHeaderCarrierProvider
+
+abstract class FrontendController(override val controllerComponents: MessagesControllerComponents)
+    extends FrontendBaseController
 
 trait FrontendHeaderCarrierProvider {
   implicit protected def hc(implicit request: RequestHeader): HeaderCarrier =


### PR DESCRIPTION
At the moment most services extend a base trait rather than an abstract class. This PR provides a trait implementation to make migration easier. This is also a pattern that exists in Play itself, for example there’s a `MessagesAbstractController` which is a trait and a `MessagesBaseController` which is an abstract class but they both do the same thing.