### PR TITLE
replace deprecated play.crypto.secret key

### DIFF
--- a/src/main/resources/backend.conf
+++ b/src/main/resources/backend.conf
@@ -18,7 +18,7 @@
 # If you deploy your application to several instances be sure to use the same key!
 
 # These keys are for local development only!
-play.crypto.secret = "yNhI04vHs9<_HWbC`]20u`37=NGLGYY5:0Tg5?y`W<NoJnXWqmjcgZBec@rOxb^G"
+play.http.secret.key = "yNhI04vHs9<_HWbC`]20u`37=NGLGYY5:0Tg5?y`W<NoJnXWqmjcgZBec@rOxb^G"
 
 # Use legacy way of encoding cookies instead of JWT which is the default in Play 2.6
 play.modules.disabled += "play.api.mvc.CookiesModule"


### PR DESCRIPTION
referring to old configuration key caused warning during app startup

`backend.conf @ jar:file:/Users/peterperhac/Library/Caches/Coursier/v1/https/dl.bintray.com/hmrc/releases/uk/gov/hmrc/bootstrap-play-26_2.11/0.37.0/bootstrap-play-26_2.11-0.37.0.jar!/backend.conf: 21: play.crypto.secret is deprecated, use play.http.secret.key instead`