### PR TITLE
controller-implicits: Added trait for frontend controller implicits

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/bootstrap/controller/FrontendController.scala
+++ b/src/main/scala/uk/gov/hmrc/play/bootstrap/controller/FrontendController.scala
@@ -16,9 +16,12 @@
 
 package uk.gov.hmrc.play.bootstrap.controller
 
+import play.api.i18n.I18nSupport
 import play.api.mvc._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.HeaderCarrierConverter
+
+import scala.concurrent.ExecutionContext
 
 trait FrontendBaseController
   extends MessagesBaseController
@@ -34,3 +37,7 @@ trait FrontendHeaderCarrierProvider {
     HeaderCarrierConverter.fromHeadersAndSessionAndRequest(request.headers, Some(request.session), Some(request))
 }
 
+trait FrontendControllerImplicits extends I18nSupport {
+  self: BaseControllerHelpers =>
+  implicit def ec: ExecutionContext = controllerComponents.executionContext
+}


### PR DESCRIPTION
This trait would be mixed in to implicitly provide execution context and messages. This would remove the need for injecting execution context and injecting messagesApi when extending I18nSupport.

See:
https://github.com/daniel-manning/play-26-frontend/compare/move_to_26...danewatts:move_to_26
For example usage.