### PR TITLE
BDOG-352 Move HeadersFilter to after SessionCookieCryptoFilter

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/FrontendFilters.scala
+++ b/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/FrontendFilters.scala
@@ -44,8 +44,8 @@ class FrontendFilters @Inject()(
 
   val frontendFilters = Seq(
     metricsFilter,
-    headersFilter,
     sessionCookieCryptoFilter,
+    headersFilter,
     deviceIdFilter,
     loggingFilter,
     frontendAuditFilter,


### PR DESCRIPTION
Since headersFilter tries to access the session, warnings are generated since the cookie headers are encrypted. Reordering the filters will avoid the warnings in logs.