### PR TITLE
TEL-1135 Don't default log requestchain & timestmp

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/LoggingFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/LoggingFilter.scala
@@ -70,12 +70,12 @@ trait LoggingFilter extends Filter {
       .andThen {
         case Success(result) =>
           logger.info(
-            s"${ld.requestChain.value} $start ${rh.method} ${rh.uri} ${result.header.status} ${elapsedTime}ms"
+            s"${rh.method} ${rh.uri} ${result.header.status} ${elapsedTime}ms"
           )
 
         case Failure(NonFatal(t)) =>
           logger.info(
-            s"${ld.requestChain.value} $start ${rh.method} ${rh.uri} $t ${elapsedTime}ms"
+            s"${rh.method} ${rh.uri} $t ${elapsedTime}ms"
           )
       }
   }

--- a/src/test/scala/uk/gov/hmrc/play/bootstrap/filters/LoggingFilterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/bootstrap/filters/LoggingFilterSpec.scala
@@ -16,13 +16,11 @@
 
 package uk.gov.hmrc.play.bootstrap.filters
 
-import java.time.format.DateTimeFormatter
-import java.time.{Instant, LocalDateTime, ZoneId, ZoneOffset}
-import java.util.{Date, Locale, TimeZone}
+import java.util.{Date, TimeZone}
 
 import akka.stream.Materializer
 import org.apache.commons.lang3.time.FastDateFormat
-import org.joda.time.{DateTime, DateTimeUtils}
+import org.joda.time.DateTimeUtils
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.Eventually
 import org.scalatest.mockito.MockitoSugar
@@ -100,8 +98,8 @@ class LoggingFilterSpec
 
       val result = await(loggingFilter(testReqToResp)(requestWithHandlerInAttrs))
 
-      logger.loggedMessage.get should fullyMatch regex
-        s"""[a-f0-9]{3,4} \\Q$requestStartString\\E GET \\/ ${result.header.status} ${expectedRequestDurationInMillis}ms"""
+      logger.loggedMessage.get shouldEqual
+        s"""GET / ${result.header.status} ${expectedRequestDurationInMillis}ms"""
     }
 
     "log elapsed time and exception and return the failed future unchanged" in new Setup {
@@ -122,8 +120,8 @@ class LoggingFilterSpec
 
       intercept[Exception](await(loggingFilter(_ => Future.failed(ex))(requestWithHandlerInAttrs))) shouldBe ex
 
-      logger.loggedMessage.get should fullyMatch regex
-        s"""[a-f0-9]{3,4} \\Q$requestStartString\\E GET \\/ $ex ${expectedRequestDurationInMillis}ms"""
+      logger.loggedMessage.get shouldEqual
+        s"""GET / $ex ${expectedRequestDurationInMillis}ms"""
     }
   }
 


### PR DESCRIPTION
This functionality was implemented 6 years ago and there doesn't seem to be anyone around any more that was originally there to explain its purpose. We already have log creation and log ingestion date-time as metadata in Kibana, and are removing this in response to a request from developers of it unnecessarily polluting their logs.