### PR TITLE
play.crypto.secret -> play.http.secret.key in frontend.conf and backend.conf

### DIFF
--- a/src/main/resources/backend.conf
+++ b/src/main/resources/backend.conf
@@ -18,7 +18,7 @@
 # If you deploy your application to several instances be sure to use the same key!
 
 # These keys are for local development only!
-play.crypto.secret = "yNhI04vHs9<_HWbC`]20u`37=NGLGYY5:0Tg5?y`W<NoJnXWqmjcgZBec@rOxb^G"
+play.http.secret.key = "yNhI04vHs9<_HWbC`]20u`37=NGLGYY5:0Tg5?y`W<NoJnXWqmjcgZBec@rOxb^G"
 
 # Use legacy way of encoding cookies instead of JWT which is the default in Play 2.6
 play.modules.disabled += "play.api.mvc.CookiesModule"

--- a/src/main/resources/frontend.conf
+++ b/src/main/resources/frontend.conf
@@ -18,7 +18,7 @@
 # If you deploy your application to several instances be sure to use the same key!
 
 # These keys are for local development only!
-play.crypto.secret = "yNhI04vHs9<_HWbC`]20u`37=NGLGYY5:0Tg5?y`W<NoJnXWqmjcgZBec@rOxb^G"
+play.http.secret.key = "yNhI04vHs9<_HWbC`]20u`37=NGLGYY5:0Tg5?y`W<NoJnXWqmjcgZBec@rOxb^G"
 cookie.encryption.key = "gvBoGdgzqG1AarzF1LY0zQ=="
 queryParameter.encryption = ${cookie.encryption}
 sso.encryption.key = "P5xsJ9Nt+quxGZzB4DeLfw=="
@@ -82,4 +82,3 @@ csrfexceptions.whitelist = ["/ida/login", "/ssoin", "/contact/problem_reports"]
 akka.actor.default-dispatcher {
   executor = "uk.gov.hmrc.play.bootstrap.dispatchers.MDCPropagatingExecutorServiceConfigurator"
 }
-


### PR DESCRIPTION
Including backend.conf as a dependency in repositories results in warnings (see below) when running integration tests, meaning the console is unnecessarily flooded with deprecation warnings.

>`2020-02-06 15:40:03,093 level=[WARN] logger=[application] thread=[pool-1-thread-1] rid=[] user=[] message=[backend.conf @ jar:file:/Users/XXXXX/Library/Caches/Coursier/v1/https/dl.bintray.com/hmrc/releases/uk/gov/hmrc/bootstrap-play-26_2.12/1.3.0/bootstrap-play-26_2.12-1.3.0.jar!/backend.conf: 21: play.crypto.secret is deprecated, use play.http.secret.key instead] 
>`

This PR addresses these warnings.