### PR TITLE
replace-deprecated-config

### DIFF
--- a/src/main/resources/frontend.conf
+++ b/src/main/resources/frontend.conf
@@ -18,7 +18,7 @@
 # If you deploy your application to several instances be sure to use the same key!
 
 # These keys are for local development only!
-play.crypto.secret = "yNhI04vHs9<_HWbC`]20u`37=NGLGYY5:0Tg5?y`W<NoJnXWqmjcgZBec@rOxb^G"
+play.http.secret.key = "yNhI04vHs9<_HWbC`]20u`37=NGLGYY5:0Tg5?y`W<NoJnXWqmjcgZBec@rOxb^G"
 cookie.encryption.key = "gvBoGdgzqG1AarzF1LY0zQ=="
 queryParameter.encryption = ${cookie.encryption}
 sso.encryption.key = "P5xsJ9Nt+quxGZzB4DeLfw=="


### PR DESCRIPTION
Replacing the deprecated 'play.crypto.secret' with 'play.http.secret.key' to prevent runtime deprecation warnings.

`[WARN]  2020-03-24 11:19:23,863 backend.conf @ jar:file:/Users/<user>/Library/Caches/Coursier/v1/https/dl.bintray.com/hmrc/releases/uk/gov/hmrc/bootstrap-play-26_2.12/1.3.0/bootstrap-play-26_2.12-1.3.0.jar!/backend.conf: 21: play.crypto.secret is deprecated, use play.http.secret.key instead 
`